### PR TITLE
fix: novatorem title is not center when no cover image

### DIFF
--- a/api/templates/spotify.novatorem.html.j2
+++ b/api/templates/spotify.novatorem.html.j2
@@ -46,9 +46,9 @@
 
       .text-container {
         align-self: flex-end;
-
         width: 200px;
         height: 70px;
+        flex-grow: 1;
       }
 
       .artist {


### PR DESCRIPTION
- fix novatorem title is not center when no cover image