### PR TITLE
Added feature to censor explicit language for song name as well as artist name

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ Pillow==11.3.0
 colorgram.py==1.2.0
 markupsafe==3.0.3
 gunicorn==23.0.0
+profanityfilter==2.1.0
 
 # Test dependencies for CI/CD
 pytest==8.4.2

--- a/api/templates/callback.html.j2
+++ b/api/templates/callback.html.j2
@@ -99,6 +99,12 @@
               <span>Interchange Artist with Song name</span>
             </label>
           </div>
+        <div class="col s12 m3">
+          <label class="row">
+            <input type="checkbox" class="filled-in" id="profanity-checkbox" />
+            <span>Censor Profanity</span>
+          </label>
+        </div>
       </div>
 
       <div class="row center">
@@ -230,7 +236,8 @@
       theme: 'default',
       show_offline: false,
       background_color: "121212",
-      interchange:false
+      interchange:false,
+      profanity: false
     };
     var openSong = false;
 
@@ -273,6 +280,11 @@
 
     $("#show-offline-checkbox").change(function() {
       urlParams.show_offline = this.checked;
+      updateUrl();
+    });
+
+    $("#profanity-checkbox").change(function() {
+      urlParams.profanity = this.checked;
       updateUrl();
     });
 

--- a/tests/test_util_profanity.py
+++ b/tests/test_util_profanity.py
@@ -1,0 +1,25 @@
+import sys
+import os
+
+# Add the parent directory to the path to import the util module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_profanity_check_clean_text():
+    """Test that clean text is returned unchanged."""
+    from util.profanity import profanity_check
+
+    result = profanity_check("Hello World")
+
+    assert result == "Hello World"
+
+
+def test_profanity_check_profane_text():
+    """Test that profane text is censored."""
+    from util.profanity import profanity_check
+
+    result = profanity_check("fuck")
+
+    # The exact censoring depends on the library, but should be different
+    assert result != "fuck"
+    assert "*" in result  # Should contain censoring characters

--- a/util/profanity.py
+++ b/util/profanity.py
@@ -1,0 +1,11 @@
+from profanityfilter import ProfanityFilter
+
+pf = ProfanityFilter()
+
+
+def profanity_check(name):
+
+    if pf.is_clean(name):
+        return name
+
+    return pf.censor(name)


### PR DESCRIPTION
Added feature to censor explicit language for song name as well as artist name by using profanityfilter library and creating two functions in app/view.py (line 342-344):

profanity_check_n(name): marks the whole word with asterik.
<img width="1915" height="1076" alt="Screenshot from 2025-10-07 00-02-16" src="https://github.com/user-attachments/assets/b6b3d93d-da96-474d-b4c7-8f2c61f0035d" />


profanity_check(name): marks the whole word as asterik except the first and last letter of that censored word.
<img width="1915" height="1076" alt="Screenshot from 2025-10-07 00-03-58" src="https://github.com/user-attachments/assets/8f5782dd-7681-41e7-8f7d-2a6df4b2515f" />


Currently, the profanity_check function is being used so as to maintain some context about the word being censored.
I also changed ' BASE_URL ' in .envexample to 'http://127.0.0.1:3000/api' as spotify no longer accepts localhost in Request URI