### PR TITLE
feat: add ability to hide "Remaster" variants from song titles

### DIFF
--- a/api/templates/callback.html.j2
+++ b/api/templates/callback.html.j2
@@ -105,6 +105,12 @@
             <span>Censor Profanity</span>
           </label>
         </div>
+        <div class="col s12 m3">
+          <label class="row">
+            <input type="checkbox" class="filled-in" id="hide-remaster-checkbox" />
+            <span>Hide Remaster</span>
+          </label>
+        </div>
       </div>
 
       <div class="row center">
@@ -237,7 +243,8 @@
       show_offline: false,
       background_color: "121212",
       interchange:false,
-      profanity: false
+      profanity: false,
+      hide_remaster: false
     };
     var openSong = false;
 
@@ -285,6 +292,11 @@
 
     $("#profanity-checkbox").change(function() {
       urlParams.profanity = this.checked;
+      updateUrl();
+    });
+
+    $("#hide-remaster-checkbox").change(function() {
+      urlParams.hide_remaster = this.checked;
       updateUrl();
     });
 

--- a/api/view.py
+++ b/api/view.py
@@ -4,6 +4,7 @@ from dotenv import load_dotenv, find_dotenv
 
 from util.firestore import get_firestore_db
 from util.profanity import profanity_check
+from util.remaster import remove_remaster
 
 load_dotenv(find_dotenv())
 
@@ -352,6 +353,7 @@ def catch_all(path):
     interchange = request.args.get("interchange", default="false") == "true"
     mode = request.args.get("mode", default="light")
     is_enable_profanity = request.args.get("profanity", default="false") == "true"
+    hide_remaster = request.args.get("hide_remaster", default="false") == "true"
 
     # Handle invalid request
     if not uid:
@@ -453,6 +455,10 @@ def catch_all(path):
     if is_enable_profanity:
         artist_name = profanity_check(artist_name)
         song_name = profanity_check(song_name)
+
+    # Strip remaster annotations from song title
+    if hide_remaster:
+        song_name = remove_remaster(song_name)
 
     if interchange:
         x = artist_name

--- a/tests/test_util_remaster.py
+++ b/tests/test_util_remaster.py
@@ -1,0 +1,44 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from util.remaster import remove_remaster
+
+
+def test_no_remaster_unchanged():
+    assert remove_remaster("Hotel California") == "Hotel California"
+
+
+def test_remaster_suffix_dash():
+    assert remove_remaster("Hotel California - 2013 Remaster") == "Hotel California"
+
+
+def test_remaster_suffix_parens():
+    assert remove_remaster("Come Together (Remastered)") == "Come Together"
+
+
+def test_remastered_with_year_parens():
+    assert remove_remaster("Roxanne (Remastered 2003)") == "Roxanne"
+
+
+def test_remaster_year_before_keyword():
+    assert remove_remaster("Starman - 2012 Remaster") == "Starman"
+
+
+def test_remastered_version():
+    assert remove_remaster("Heroes - Remastered Version") == "Heroes"
+
+
+def test_remastered_year_version():
+    assert remove_remaster("Life On Mars? (2015 Remastered Version)") == "Life On Mars?"
+
+
+def test_case_insensitive():
+    assert remove_remaster("Song Title - REMASTERED") == "Song Title"
+
+
+def test_remaster_not_mid_title():
+    """Remaster text in the middle of a title must not be removed."""
+    title = "Remastered Soul"
+    assert remove_remaster(title) == "Remastered Soul"

--- a/util/remaster.py
+++ b/util/remaster.py
@@ -1,0 +1,27 @@
+import re
+
+# Matches common "Remaster" / "Remastered" suffixes appended to song titles.
+# Examples handled:
+#   "Song Title - 2020 Remaster"
+#   "Song Title (2020 Remaster)"
+#   "Song Title (Remastered)"
+#   "Song Title - Remastered 2020"
+#   "Song Title (Remastered 2020 Version)"
+_REMASTER_RE = re.compile(
+    r"""
+    [\s\-–]+            # separator: whitespace and/or dash
+    [\(\[]?             # optional opening bracket
+    (?:\d{4}\s+)?       # optional year before keyword
+    Remaster(?:ed)?     # "Remaster" or "Remastered"
+    (?:\s+\d{4})?       # optional year after keyword
+    (?:\s+Version)?     # optional trailing "Version"
+    [\)\]]?             # optional closing bracket
+    \s*$                # up to end of string
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def remove_remaster(name: str) -> str:
+    """Return *name* with any remaster annotation stripped from the end."""
+    return _REMASTER_RE.sub("", name).strip()


### PR DESCRIPTION
Closes #133 

This pull request adds a new "Hide Remaster" feature to the application, allowing users to optionally strip "Remaster" or "Remastered" annotations from song titles in the UI and API responses. The change includes UI updates, backend support, a new utility for removing remaster annotations, and comprehensive tests.

**Hide Remaster feature:**

* Added a "Hide Remaster" checkbox to the UI in `callback.html.j2`, allowing users to enable or disable the feature.
* Updated the JavaScript logic in `callback.html.j2` to track the `hide_remaster` setting and update the URL parameters accordingly. [[1]](diffhunk://#diff-76b84d87338d6feabffde8d40a71531d8806bfa4cf3721b35327d1b0af3c79c2L240-R247) [[2]](diffhunk://#diff-76b84d87338d6feabffde8d40a71531d8806bfa4cf3721b35327d1b0af3c79c2R298-R302)

**Backend support:**

* Modified `view.py` to read the `hide_remaster` parameter from requests and, if enabled, strip remaster annotations from song titles using a new utility function. [[1]](diffhunk://#diff-2894945796aa0e8fb88d42856deb380494255d0bb09705b30651760c6f62b762R356) [[2]](diffhunk://#diff-2894945796aa0e8fb88d42856deb380494255d0bb09705b30651760c6f62b762R459-R462)
* Imported the new `remove_remaster` function in `view.py`.

**Utility and tests:**

* Implemented `remove_remaster` in `util/remaster.py` to robustly strip various remaster/remastered suffixes from song titles using regular expressions.
* Added a suite of tests in `tests/test_util_remaster.py` to ensure correct behavior of the `remove_remaster` function for a variety of cases.

<img width="1903" height="908" alt="image" src="https://github.com/user-attachments/assets/82cd07fb-5ff5-4720-983c-5ba13409fbd5" />
-
<img width="1902" height="908" alt="image" src="https://github.com/user-attachments/assets/44e24972-b722-41fd-82d1-24f9c1002199" />