### PR TITLE
fix: resolve Vercel serverless deployment issues (uv, sys.path, error handling)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,12 @@
-from flask import Flask, redirect
 import importlib
+import os
+import sys
+
+from flask import Flask, redirect
+
+# Ensure the api/ directory is on sys.path so sibling modules resolve correctly
+# when running as a Vercel serverless function.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Import legacy handlers (order matters for Firebase init)
 login_module = importlib.import_module("login")

--- a/api/callback.py
+++ b/api/callback.py
@@ -1,15 +1,16 @@
-from flask import Flask, Response, jsonify, render_template, redirect, request
 from base64 import b64decode
-from dotenv import load_dotenv, find_dotenv
+
+from dotenv import find_dotenv, load_dotenv
+from flask import Flask, Response, jsonify, redirect, render_template, request
 
 load_dotenv(find_dotenv())
 
-from firebase_admin import credentials
-from firebase_admin import firestore
-import firebase_admin
-
-import os
 import json
+import os
+
+import firebase_admin
+from firebase_admin import credentials, firestore
+
 from util import spotify
 
 print("Starting Server")
@@ -36,9 +37,22 @@ def catch_all(path):
         return Response("not ok")
 
     token_info = spotify.generate_token(code)
+
+    if "access_token" not in token_info:
+        error = token_info.get("error", "unknown")
+        desc = token_info.get("error_description", "")
+        return Response(f"Token exchange failed: {error} - {desc}", status=400)
+
     access_token = token_info["access_token"]
 
-    spotify_user = spotify.get_user_profile(access_token)
+    profile_resp = spotify.get_user_profile_raw(access_token)
+    if profile_resp.status_code != 200 or not profile_resp.text.strip():
+        return Response(
+            f"Spotify profile fetch failed: HTTP {profile_resp.status_code} - {profile_resp.text[:300]}",
+            status=502,
+        )
+
+    spotify_user = profile_resp.json()
     user_id = spotify_user["id"]
 
     doc_ref = db.collection("users").document(user_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[project]
+name = "spotify-github-profile"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "Flask==3.1.2",
+    "Werkzeug==3.1.3",
+    "requests==2.32.5",
+    "python-dotenv==1.1.1",
+    "firebase-admin==7.1.0",
+    "Pillow==11.3.0",
+    "colorgram.py==1.2.0",
+    "markupsafe==3.0.3",
+    "gunicorn==23.0.0",
+    "profanityfilter==2.1.0",
+]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q --strict-markers --strict-config"

--- a/util/spotify.py
+++ b/util/spotify.py
@@ -1,13 +1,14 @@
 from base64 import b64encode
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 load_dotenv(find_dotenv())
 
-import requests
 import json
 import os
 import random
+
+import requests
 
 SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
 SPOTIFY_SECRET_ID = os.getenv("SPOTIFY_SECRET_ID")
@@ -25,14 +26,17 @@ SPOTIFY_URL_RECENTLY_PLAY = (
 SPOTIFY_URL_GENERATE_TOKEN = "https://accounts.spotify.com/api/token"
 SPOTIFY_URL_USER_INFO = "https://api.spotify.com/v1/me"
 
+
 class InvalidTokenError(Exception):
     pass
+
 
 def get_authorization():
 
     return b64encode(f"{SPOTIFY_CLIENT_ID}:{SPOTIFY_SECRET_ID}".encode()).decode(
         "ascii"
     )
+
 
 def generate_token(authorization_code):
 
@@ -49,6 +53,7 @@ def generate_token(authorization_code):
 
     return response_json
 
+
 def refresh_token(refresh_token):
 
     data = {
@@ -63,6 +68,13 @@ def refresh_token(refresh_token):
 
     return response_json
 
+
+def get_user_profile_raw(access_token):
+    """Return the raw Response object for flexible error handling by callers."""
+    headers = {"Authorization": f"Bearer {access_token}"}
+    return requests.get(SPOTIFY_URL_USER_INFO, headers=headers)
+
+
 def get_user_profile(access_token):
 
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -71,6 +83,7 @@ def get_user_profile(access_token):
     response_json = response.json()
 
     return response_json
+
 
 def get_recently_play(access_token):
 
@@ -83,6 +96,7 @@ def get_recently_play(access_token):
 
     response_json = response.json()
     return response_json
+
 
 def get_now_playing(access_token):
 


### PR DESCRIPTION
## Problem

When self-hosting on Vercel using the current Python runtime (which uses `uv` for dependency management), three issues prevent the app from starting or functioning:

### 1. `uv lock` fails at build time
Vercel's new Python runtime calls `uv lock` to resolve dependencies. `uv` requires a `[project]` table in `pyproject.toml`, which was missing — only `[tool.*]` sections existed.

**Error:**
```
error: No 'project' table found in: /vercel/path0/pyproject.toml
```

### 2. `ModuleNotFoundError: No module named 'login'`
When Vercel runs `api/app.py` as a serverless function entry-point, the `api/` directory is not on `sys.path`. The dynamic `importlib.import_module("login")` calls therefore fail at startup.

### 3. Silent crash on Spotify API errors
If the token exchange or profile fetch returns an unexpected response (e.g. empty body, non-200 status), the app raises an unhandled `JSONDecodeError` and returns a generic 500. The actual Spotify error message is swallowed.

## Fix

1. **`pyproject.toml`** — add a `[project]` table listing the runtime dependencies (mirrors `api/requirements.txt`).
2. **`api/app.py`** — insert `api/` into `sys.path` before the dynamic imports.
3. **`api/callback.py` + `util/spotify.py`** — check HTTP status and body before calling `.json()`; return a readable `400`/`502` response with the Spotify error message instead of crashing.