### PR TITLE
security: harden Spotify OAuth state and token lifecycle

### DIFF
--- a/api/callback.py
+++ b/api/callback.py
@@ -1,17 +1,16 @@
-from base64 import b64decode
-
-from dotenv import find_dotenv, load_dotenv
-from flask import Flask, Response, jsonify, redirect, render_template, request
-
-load_dotenv(find_dotenv())
-
+import hmac
 import json
 import os
+from base64 import b64decode
 
 import firebase_admin
+from dotenv import find_dotenv, load_dotenv
 from firebase_admin import credentials, firestore
+from flask import Flask, Response, make_response, render_template, request
 
 from util import spotify
+
+load_dotenv(find_dotenv())
 
 print("Starting Server")
 
@@ -27,30 +26,46 @@ db = firestore.client()
 app = Flask(__name__)
 
 
+def _clear_oauth_state_cookie(response):
+    response.delete_cookie(spotify.OAUTH_STATE_COOKIE_NAME, path="/")
+    return response
+
+
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def catch_all(path):
     code = request.args.get("code")
 
     if code is None:
-        # TODO: no code
         return Response("not ok")
+
+    state = request.args.get("state")
+    expected_state = request.cookies.get(spotify.OAUTH_STATE_COOKIE_NAME)
+    if (
+        not state
+        or not expected_state
+        or not hmac.compare_digest(state, expected_state)
+    ):
+        return Response("Invalid OAuth state", status=400)
 
     token_info = spotify.generate_token(code)
 
     if "access_token" not in token_info:
         error = token_info.get("error", "unknown")
         desc = token_info.get("error_description", "")
-        return Response(f"Token exchange failed: {error} - {desc}", status=400)
+        response = Response(f"Token exchange failed: {error} - {desc}", status=400)
+        return _clear_oauth_state_cookie(response)
 
+    token_info = spotify.normalize_token_info(token_info)
     access_token = token_info["access_token"]
 
     profile_resp = spotify.get_user_profile_raw(access_token)
     if profile_resp.status_code != 200 or not profile_resp.text.strip():
-        return Response(
+        response = Response(
             f"Spotify profile fetch failed: HTTP {profile_resp.status_code} - {profile_resp.text[:300]}",
             status=502,
         )
+        return _clear_oauth_state_cookie(response)
 
     spotify_user = profile_resp.json()
     user_id = spotify_user["id"]
@@ -63,7 +78,8 @@ def catch_all(path):
         "BASE_URL": spotify.BASE_URL,
     }
 
-    return render_template("callback.html.j2", **rendered_data)
+    response = make_response(render_template("callback.html.j2", **rendered_data))
+    return _clear_oauth_state_cookie(response)
 
 
 if __name__ == "__main__":

--- a/api/callback.py
+++ b/api/callback.py
@@ -34,11 +34,6 @@ def _clear_oauth_state_cookie(response):
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def catch_all(path):
-    code = request.args.get("code")
-
-    if code is None:
-        return Response("not ok")
-
     state = request.args.get("state")
     expected_state = request.cookies.get(spotify.OAUTH_STATE_COOKIE_NAME)
     if (
@@ -46,17 +41,46 @@ def catch_all(path):
         or not expected_state
         or not hmac.compare_digest(state, expected_state)
     ):
-        return Response("Invalid OAuth state", status=400)
+        return Response("Invalid OAuth state", status=400, mimetype="text/plain")
+
+    oauth_error = request.args.get("error")
+    if oauth_error:
+        response = Response(
+            f"Spotify authorization failed: {oauth_error}",
+            status=400,
+            mimetype="text/plain",
+        )
+        return _clear_oauth_state_cookie(response)
+
+    code = request.args.get("code")
+    if not code:
+        response = Response(
+            "Missing authorization code", status=400, mimetype="text/plain"
+        )
+        return _clear_oauth_state_cookie(response)
 
     token_info = spotify.generate_token(code)
 
     if "access_token" not in token_info:
         error = token_info.get("error", "unknown")
         desc = token_info.get("error_description", "")
-        response = Response(f"Token exchange failed: {error} - {desc}", status=400)
+        response = Response(
+            f"Token exchange failed: {error} - {desc}",
+            status=400,
+            mimetype="text/plain",
+        )
         return _clear_oauth_state_cookie(response)
 
-    token_info = spotify.normalize_token_info(token_info)
+    try:
+        token_info = spotify.normalize_token_info(token_info)
+    except ValueError:
+        response = Response(
+            "Token exchange returned invalid token metadata",
+            status=502,
+            mimetype="text/plain",
+        )
+        return _clear_oauth_state_cookie(response)
+
     access_token = token_info["access_token"]
 
     profile_resp = spotify.get_user_profile_raw(access_token)
@@ -64,6 +88,7 @@ def catch_all(path):
         response = Response(
             f"Spotify profile fetch failed: HTTP {profile_resp.status_code} - {profile_resp.text[:300]}",
             status=502,
+            mimetype="text/plain",
         )
         return _clear_oauth_state_cookie(response)
 

--- a/api/login.py
+++ b/api/login.py
@@ -1,4 +1,6 @@
-from flask import Flask, Response, jsonify, render_template, redirect
+import secrets
+
+from flask import Flask, redirect
 
 from util import spotify
 
@@ -8,10 +10,27 @@ app = Flask(__name__)
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def catch_all(path):
+    state = secrets.token_urlsafe(32)
+    login_url = (
+        "https://accounts.spotify.com/authorize"
+        f"?client_id={spotify.SPOTIFY_CLIENT_ID}"
+        "&response_type=code"
+        "&scope=user-read-currently-playing,user-read-recently-played"
+        f"&redirect_uri={spotify.REDIRECT_URI}"
+        f"&state={state}"
+    )
 
-    login_url = f"https://accounts.spotify.com/authorize?client_id={spotify.SPOTIFY_CLIENT_ID}&response_type=code&scope=user-read-currently-playing,user-read-recently-played&redirect_uri={spotify.REDIRECT_URI}"
-
-    return redirect(login_url)
+    response = redirect(login_url)
+    response.set_cookie(
+        spotify.OAUTH_STATE_COOKIE_NAME,
+        state,
+        max_age=spotify.OAUTH_STATE_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=bool(spotify.REDIRECT_URI and spotify.REDIRECT_URI.startswith("https://")),
+        samesite="Lax",
+        path="/",
+    )
+    return response
 
 
 if __name__ == "__main__":

--- a/api/view.py
+++ b/api/view.py
@@ -269,23 +269,44 @@ def get_access_token(uid):
     if not refresh_token_value:
         return None
 
-    new_token = spotify.refresh_token(refresh_token_value)
+    try:
+        new_token = spotify.refresh_token(refresh_token_value)
+    except requests.exceptions.RequestException as exc:
+        raise spotify.TokenRefreshError(
+            "Spotify token refresh request failed"
+        ) from exc
+
+    refresh_error = new_token.get("error")
 
     # A revoked refresh token requires a fresh authorization flow.
-    if new_token.get("error") == "invalid_grant":
+    if refresh_error == "invalid_grant":
         doc_ref = db.collection("users").document(uid)
         doc_ref.delete()
         delete_cache_token_info(uid)
         return None
 
-    if "access_token" not in new_token or "expires_in" not in new_token:
-        return None
+    # Other errors are not proof that the stored refresh token is invalid.
+    if refresh_error:
+        raise spotify.TokenRefreshError(
+            f"Spotify token refresh failed: {refresh_error}"
+        )
 
-    refreshed_token_info = spotify.normalize_token_info(
-        new_token,
-        existing_refresh_token=refresh_token_value,
-        now=current_ts,
-    )
+    if "access_token" not in new_token or "expires_in" not in new_token:
+        raise spotify.TokenRefreshError(
+            "Spotify token refresh returned incomplete token metadata"
+        )
+
+    try:
+        refreshed_token_info = spotify.normalize_token_info(
+            new_token,
+            existing_refresh_token=refresh_token_value,
+            now=current_ts,
+        )
+    except ValueError as exc:
+        raise spotify.TokenRefreshError(
+            "Spotify token refresh returned invalid token metadata"
+        ) from exc
+
     update_data = {
         key: refreshed_token_info[key]
         for key in ("access_token", "refresh_token", "expires_in", "expired_ts")
@@ -308,7 +329,7 @@ def get_song_info(uid, show_offline):
     progress_ms = None
     duration_ms = None
 
-    # Handle refrest_token revoke or invalid token
+    # Handle refresh_token revoke or invalid token
     if access_token is None:
         raise spotify.InvalidTokenError("Invalid Spotify access_token or refresh_token")
 
@@ -374,11 +395,16 @@ def catch_all(path):
         item, is_now_playing, progress_ms, duration_ms = get_song_info(
             uid, show_offline
         )
-    except spotify.InvalidTokenError as e:
-
-        # Handle invalid token
+    except spotify.InvalidTokenError:
+        # Handle invalid or revoked credentials.
         return Response(
             "Error: Invalid Spotify access_token or refresh_token. Possibly the token revoked. Please re-login at https://github.com/kittinan/spotify-github-profile"
+        )
+    except spotify.TokenRefreshError:
+        # A temporary refresh failure must not be presented as revoked credentials.
+        return Response(
+            "Error: Spotify token refresh temporarily unavailable. Please try again later.",
+            status=502,
         )
 
     if (show_offline and not is_now_playing) or (item is None):

--- a/api/view.py
+++ b/api/view.py
@@ -254,46 +254,50 @@ def get_access_token(uid):
             print("not exist data in firebase: {}".format(uid))
             return None
 
-        token_info = doc.to_dict()
-
+        token_info = doc.to_dict() or {}
         CACHE_TOKEN_INFO[uid] = token_info
 
     current_ts = int(time())
-    access_token = token_info.get("access_token", None)
-    print(access_token)
-
-    # Check token expired
+    access_token = token_info.get("access_token")
     expired_ts = token_info.get("expired_ts")
-    if expired_ts is None or current_ts >= expired_ts:
-        # Refresh token
-        refresh_token = token_info["refresh_token"]
 
-        new_token = spotify.refresh_token(refresh_token)
+    # Reuse a valid access token without exposing it in application logs.
+    if access_token and expired_ts is not None and current_ts < expired_ts:
+        return access_token
 
-        # Handle refresh token revoke
-        if new_token.get("error") == "invalid_grant":
-            # Delete token in firebase
-            doc_ref = db.collection("users").document(uid)
-            doc_ref.delete()
+    refresh_token_value = token_info.get("refresh_token")
+    if not refresh_token_value:
+        return None
 
-            # Delete token in memory cache
-            delete_cache_token_info(uid)
-            return None
+    new_token = spotify.refresh_token(refresh_token_value)
 
-        expired_ts = int(time()) + new_token["expires_in"]
-        update_data = {
-            "access_token": new_token["access_token"],
-            "expired_ts": expired_ts,
-        }
+    # A revoked refresh token requires a fresh authorization flow.
+    if new_token.get("error") == "invalid_grant":
         doc_ref = db.collection("users").document(uid)
-        doc_ref.update(update_data)
+        doc_ref.delete()
+        delete_cache_token_info(uid)
+        return None
 
-        access_token = new_token["access_token"]
+    if "access_token" not in new_token or "expires_in" not in new_token:
+        return None
 
-        # Save in memory cache
-        CACHE_TOKEN_INFO[uid] = update_data
+    refreshed_token_info = spotify.normalize_token_info(
+        new_token,
+        existing_refresh_token=refresh_token_value,
+        now=current_ts,
+    )
+    update_data = {
+        key: refreshed_token_info[key]
+        for key in ("access_token", "refresh_token", "expires_in", "expired_ts")
+        if key in refreshed_token_info
+    }
 
-    return access_token
+    doc_ref = db.collection("users").document(uid)
+    doc_ref.update(update_data)
+
+    merged_token_info = {**token_info, **update_data}
+    CACHE_TOKEN_INFO[uid] = merged_token_info
+    return merged_token_info["access_token"]
 
 
 def get_song_info(uid, show_offline):

--- a/tests/test_api_callback.py
+++ b/tests/test_api_callback.py
@@ -235,13 +235,30 @@ class TestRealCallbackIntegration:
         response = real_app_client.get("/?code=test_code&state=wrong_state")
         assert response.status_code == 400
         assert response.data == b"Invalid OAuth state"
+
+    @patch('util.spotify.generate_token')
+    def test_integration_callback_handles_access_denied(self, mock_generate_token, real_app_client):
+        """A denied authorization should end the state-bound flow without token exchange."""
+        real_app_client.set_cookie("spotify_oauth_state", "test_state")
+
+        response = real_app_client.get(
+            "/?error=access_denied&state=test_state"
+        )
+
+        assert response.status_code == 400
+        assert response.data == b"Spotify authorization failed: access_denied"
+        assert "spotify_oauth_state=;" in response.headers.get("Set-Cookie", "")
+        mock_generate_token.assert_not_called()
     
     def test_integration_callback_without_code(self, real_app_client):
-        """Test integration callback without authorization code."""
-        response = real_app_client.get("/")
+        """A valid state without a code or OAuth error should fail clearly."""
+        real_app_client.set_cookie("spotify_oauth_state", "test_state")
+
+        response = real_app_client.get("/?state=test_state")
         
-        assert response.status_code == 200
-        assert response.data == b"not ok"
+        assert response.status_code == 400
+        assert response.data == b"Missing authorization code"
+        assert "spotify_oauth_state=;" in response.headers.get("Set-Cookie", "")
     
     @patch('util.spotify.generate_token')
     def test_integration_spotify_error_handling(self, mock_generate_token, real_app_client):

--- a/tests/test_api_callback.py
+++ b/tests/test_api_callback.py
@@ -48,7 +48,7 @@ def test_callback_with_code(client):
 
 
 def test_callback_with_empty_code_param(client):
-    """Test callback with empty code parameter."""
+    """Test callback with empty authorization code parameter."""
     response = client.get("/?code=")
     
     # Empty string should be processed (though would fail in real Spotify auth)
@@ -97,7 +97,7 @@ def test_multiple_query_parameters(client):
     "UPPERCASE_CODE"
 ])
 def test_special_code_values(client, code):
-    """Test callback with special authorization code values."""
+    """Test callback with special code values."""
     response = client.get(f"/?code={code}")
     
     assert response.status_code == 200
@@ -200,11 +200,16 @@ class TestRealCallbackIntegration:
         mock_db.collection.return_value = mock_collection
         mock_collection.document.return_value = mock_document
 
-        # Make request with authorization code
-        response = real_app_client.get("/?code=test_auth_code")
+        # Make request with a matching OAuth state cookie/query pair.
+        real_app_client.set_cookie("spotify_oauth_state", "test_state")
+        with patch('util.spotify.time', return_value=1000):
+            response = real_app_client.get(
+                "/?code=test_auth_code&state=test_state"
+            )
 
         # Verify response
         assert response.status_code == 200
+        assert "spotify_oauth_state=;" in response.headers.get("Set-Cookie", "")
 
         # Verify Spotify API calls
         mock_generate_token.assert_called_once_with("test_auth_code")
@@ -216,8 +221,20 @@ class TestRealCallbackIntegration:
         mock_document.set.assert_called_once_with({
             "access_token": "test_access_token",
             "refresh_token": "test_refresh_token",
-            "expires_in": 3600
+            "expires_in": 3600,
+            "expired_ts": 4600
         })
+
+    def test_integration_callback_rejects_missing_or_mismatched_state(self, real_app_client):
+        """OAuth callback must be bound to the browser that started the flow."""
+        response = real_app_client.get("/?code=test_code&state=test_state")
+        assert response.status_code == 400
+        assert response.data == b"Invalid OAuth state"
+
+        real_app_client.set_cookie("spotify_oauth_state", "expected_state")
+        response = real_app_client.get("/?code=test_code&state=wrong_state")
+        assert response.status_code == 400
+        assert response.data == b"Invalid OAuth state"
     
     def test_integration_callback_without_code(self, real_app_client):
         """Test integration callback without authorization code."""
@@ -231,6 +248,7 @@ class TestRealCallbackIntegration:
         """Test integration error handling for Spotify API failures."""
         # Mock token generation to raise an exception
         mock_generate_token.side_effect = Exception("Token generation failed")
+        real_app_client.set_cookie("spotify_oauth_state", "test_state")
         
         with pytest.raises(Exception, match="Token generation failed"):
-            real_app_client.get("/?code=test_code")
+            real_app_client.get("/?code=test_code&state=test_state")

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -1,0 +1,170 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the repository root to the import path.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_login_generates_state_and_sets_hardened_cookie():
+    """The authorization request must carry a state bound to an HttpOnly cookie."""
+    from api.login import app
+
+    with patch('api.login.secrets.token_urlsafe', return_value='test_state'), \
+         patch('util.spotify.SPOTIFY_CLIENT_ID', 'test_client_id'), \
+         patch('util.spotify.REDIRECT_URI', 'https://example.com/api/callback'):
+        with app.test_client() as client:
+            response = client.get('/')
+
+    assert response.status_code == 302
+    assert 'state=test_state' in response.headers['Location']
+
+    cookie = response.headers.get('Set-Cookie', '')
+    assert 'spotify_oauth_state=test_state' in cookie
+    assert 'Max-Age=600' in cookie
+    assert 'HttpOnly' in cookie
+    assert 'Secure' in cookie
+    assert 'SameSite=Lax' in cookie
+
+
+def test_normalize_token_info_persists_expiry_and_existing_refresh_token():
+    """Refresh responses that omit refresh_token must keep the previous token."""
+    from util import spotify
+
+    normalized = spotify.normalize_token_info(
+        {
+            'access_token': 'new_access_token',
+            'expires_in': '3600',
+        },
+        existing_refresh_token='existing_refresh_token',
+        now=1000,
+    )
+
+    assert normalized == {
+        'access_token': 'new_access_token',
+        'expires_in': 3600,
+        'refresh_token': 'existing_refresh_token',
+        'expired_ts': 4600,
+    }
+
+
+def _load_view_module():
+    # Keep this test independent from the CI environment and from test order.
+    with patch.dict(os.environ, {'TESTING': 'true'}):
+        from api import view
+    return view
+
+
+def _mock_token_document(token_info):
+    document = MagicMock()
+    snapshot = MagicMock()
+    snapshot.exists = True
+    snapshot.to_dict.return_value = token_info
+    document.get.return_value = snapshot
+
+    collection = MagicMock()
+    collection.document.return_value = document
+
+    database = MagicMock()
+    database.collection.return_value = collection
+    return database, document
+
+
+def test_get_access_token_does_not_log_bearer_token(capsys):
+    """Bearer tokens are credentials and must never be printed to application logs."""
+    view = _load_view_module()
+    view.CACHE_TOKEN_INFO.clear()
+    view.CACHE_TOKEN_INFO['test_uid'] = {
+        'access_token': 'super_secret_access_token',
+        'refresh_token': 'refresh_token',
+        'expired_ts': 4600,
+    }
+
+    with patch.object(view, 'time', return_value=1000):
+        assert view.get_access_token('test_uid') == 'super_secret_access_token'
+
+    captured = capsys.readouterr()
+    assert 'super_secret_access_token' not in captured.out
+    assert 'super_secret_access_token' not in captured.err
+
+
+def test_refresh_keeps_existing_refresh_token_when_spotify_omits_rotation():
+    """A refresh response may omit refresh_token; the stored token must survive."""
+    view = _load_view_module()
+    view.CACHE_TOKEN_INFO.clear()
+
+    database, document = _mock_token_document({
+        'access_token': 'expired_access_token',
+        'refresh_token': 'existing_refresh_token',
+        'expires_in': 3600,
+        'expired_ts': 900,
+    })
+
+    with patch.object(view, 'db', database), \
+         patch.object(view, 'time', return_value=1000), \
+         patch.object(
+             view.spotify,
+             'refresh_token',
+             return_value={
+                 'access_token': 'new_access_token',
+                 'expires_in': 3600,
+             },
+         ):
+        access_token = view.get_access_token('test_uid')
+
+    assert access_token == 'new_access_token'
+    document.update.assert_called_once_with({
+        'access_token': 'new_access_token',
+        'refresh_token': 'existing_refresh_token',
+        'expires_in': 3600,
+        'expired_ts': 4600,
+    })
+    assert view.CACHE_TOKEN_INFO['test_uid']['refresh_token'] == 'existing_refresh_token'
+
+
+def test_refresh_persists_rotated_refresh_token():
+    """If Spotify rotates the refresh token, the new value must replace the old one."""
+    view = _load_view_module()
+    view.CACHE_TOKEN_INFO.clear()
+
+    database, document = _mock_token_document({
+        'access_token': 'expired_access_token',
+        'refresh_token': 'old_refresh_token',
+        'expires_in': 3600,
+        'expired_ts': 900,
+    })
+
+    with patch.object(view, 'db', database), \
+         patch.object(view, 'time', return_value=1000), \
+         patch.object(
+             view.spotify,
+             'refresh_token',
+             return_value={
+                 'access_token': 'new_access_token',
+                 'refresh_token': 'rotated_refresh_token',
+                 'expires_in': 1800,
+             },
+         ):
+        access_token = view.get_access_token('test_uid')
+
+    assert access_token == 'new_access_token'
+    document.update.assert_called_once_with({
+        'access_token': 'new_access_token',
+        'refresh_token': 'rotated_refresh_token',
+        'expires_in': 1800,
+        'expired_ts': 2800,
+    })
+    assert view.CACHE_TOKEN_INFO['test_uid']['refresh_token'] == 'rotated_refresh_token'
+
+
+def test_normalize_token_info_rejects_invalid_expiry():
+    """Invalid token metadata should fail clearly instead of poisoning the cache."""
+    from util import spotify
+
+    with pytest.raises(ValueError, match='expires_in'):
+        spotify.normalize_token_info(
+            {'access_token': 'token', 'expires_in': 'not-a-number'},
+            now=1000,
+        )

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -159,6 +159,79 @@ def test_refresh_persists_rotated_refresh_token():
     assert view.CACHE_TOKEN_INFO['test_uid']['refresh_token'] == 'rotated_refresh_token'
 
 
+def test_transient_refresh_error_does_not_delete_credentials():
+    """Only invalid_grant should invalidate persisted Spotify credentials."""
+    view = _load_view_module()
+    view.CACHE_TOKEN_INFO.clear()
+
+    database, document = _mock_token_document({
+        'access_token': 'expired_access_token',
+        'refresh_token': 'existing_refresh_token',
+        'expires_in': 3600,
+        'expired_ts': 900,
+    })
+
+    with patch.object(view, 'db', database), \
+         patch.object(view, 'time', return_value=1000), \
+         patch.object(
+             view.spotify,
+             'refresh_token',
+             return_value={
+                 'error': 'temporarily_unavailable',
+                 'error_description': 'Please retry later',
+             },
+         ):
+        with pytest.raises(view.spotify.TokenRefreshError, match='temporarily_unavailable'):
+            view.get_access_token('test_uid')
+
+    document.delete.assert_not_called()
+    document.update.assert_not_called()
+    assert view.CACHE_TOKEN_INFO['test_uid']['refresh_token'] == 'existing_refresh_token'
+
+
+def test_malformed_refresh_response_does_not_invalidate_credentials():
+    """Incomplete refresh metadata is a service failure, not revoked authorization."""
+    view = _load_view_module()
+    view.CACHE_TOKEN_INFO.clear()
+
+    database, document = _mock_token_document({
+        'access_token': 'expired_access_token',
+        'refresh_token': 'existing_refresh_token',
+        'expires_in': 3600,
+        'expired_ts': 900,
+    })
+
+    with patch.object(view, 'db', database), \
+         patch.object(view, 'time', return_value=1000), \
+         patch.object(
+             view.spotify,
+             'refresh_token',
+             return_value={'expires_in': 3600},
+         ):
+        with pytest.raises(view.spotify.TokenRefreshError, match='incomplete'):
+            view.get_access_token('test_uid')
+
+    document.delete.assert_not_called()
+    document.update.assert_not_called()
+
+
+def test_view_reports_transient_refresh_failure_without_reauth_message():
+    """Temporary refresh failures should return a retryable server error."""
+    view = _load_view_module()
+
+    with patch.object(
+        view,
+        'get_song_info',
+        side_effect=view.spotify.TokenRefreshError('temporary failure'),
+    ):
+        with view.app.test_client() as client:
+            response = client.get('/?uid=test_user')
+
+    assert response.status_code == 502
+    assert b'temporarily unavailable' in response.data
+    assert b'Please re-login' not in response.data
+
+
 def test_normalize_token_info_rejects_invalid_expiry():
     """Invalid token metadata should fail clearly instead of poisoning the cache."""
     from util import spotify

--- a/util/spotify.py
+++ b/util/spotify.py
@@ -1,12 +1,11 @@
 from base64 import b64encode
+from time import time
 
 from dotenv import find_dotenv, load_dotenv
 
 load_dotenv(find_dotenv())
 
-import json
 import os
-import random
 
 import requests
 
@@ -15,6 +14,9 @@ SPOTIFY_SECRET_ID = os.getenv("SPOTIFY_SECRET_ID")
 BASE_URL = os.getenv("BASE_URL")
 
 REDIRECT_URI = "{}/callback".format(BASE_URL)
+
+OAUTH_STATE_COOKIE_NAME = "spotify_oauth_state"
+OAUTH_STATE_MAX_AGE_SECONDS = 600
 
 # scope user-read-currently-playing,user-read-recently-played
 SPOTIFY_URL_REFRESH_TOKEN = "https://accounts.spotify.com/api/token"
@@ -29,6 +31,33 @@ SPOTIFY_URL_USER_INFO = "https://api.spotify.com/v1/me"
 
 class InvalidTokenError(Exception):
     pass
+
+
+def normalize_token_info(token_info, existing_refresh_token=None, now=None):
+    """Normalize Spotify token metadata before persisting or caching it.
+
+    Spotify may omit ``refresh_token`` from a refresh response. In that case,
+    the previous refresh token must be retained. ``expired_ts`` is stored as an
+    absolute timestamp so callers do not need to refresh a freshly-issued token
+    on its first use.
+    """
+    normalized = dict(token_info)
+
+    if existing_refresh_token and not normalized.get("refresh_token"):
+        normalized["refresh_token"] = existing_refresh_token
+
+    expires_in = normalized.get("expires_in")
+    if expires_in is not None:
+        try:
+            expires_in = max(0, int(expires_in))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Spotify token expires_in must be an integer") from exc
+
+        normalized["expires_in"] = expires_in
+        current_ts = int(time() if now is None else now)
+        normalized["expired_ts"] = current_ts + expires_in
+
+    return normalized
 
 
 def get_authorization():

--- a/util/spotify.py
+++ b/util/spotify.py
@@ -33,6 +33,12 @@ class InvalidTokenError(Exception):
     pass
 
 
+class TokenRefreshError(Exception):
+    """Raised when a refresh fails without proving the refresh token is invalid."""
+
+    pass
+
+
 def normalize_token_info(token_info, existing_refresh_token=None, now=None):
     """Normalize Spotify token metadata before persisting or caching it.
 


### PR DESCRIPTION
## Summary

This PR hardens the Spotify authorization and token lifecycle without changing the public card API.

- Adds a cryptographically random OAuth `state` value to the authorization request.
- Binds `state` to an HttpOnly, SameSite=Lax cookie and validates it with `hmac.compare_digest` in the callback.
- Handles denied/incomplete OAuth callbacks without attempting a token exchange and consumes the state cookie once a valid state-bound flow ends.
- Persists an absolute `expired_ts` when the initial access token is issued, avoiding an unnecessary refresh on first card access.
- Preserves the existing refresh token when Spotify omits `refresh_token` from a refresh response.
- Persists a rotated refresh token when Spotify returns one.
- Stops printing bearer access tokens to application logs.
- Distinguishes revoked credentials (`invalid_grant`) from transient/malformed refresh failures, so temporary Spotify errors do not delete stored authorization or incorrectly tell users to re-authenticate.
- Adds regression tests for OAuth state validation, denied/incomplete callbacks, token expiry metadata, secret logging, refresh-token rotation, and transient refresh failures.

## Security rationale

Spotify's Authorization Code flow recommends using `state` to protect the redirect flow against CSRF. Bearer access tokens are credentials and should not be emitted to application logs. Spotify refresh responses may omit a new refresh token, so the existing refresh token must be retained unless a replacement is returned. A refresh failure other than `invalid_grant` is not proof that the user's stored authorization is invalid and must not delete those credentials.

References:
- https://developer.spotify.com/documentation/web-api/tutorials/code-flow
- https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens

## Compatibility

- Existing `/api/view` parameters and normal rendering behavior are unchanged.
- No new secrets are required; `expired_ts` is additive token metadata.
- Authorization flows started before deployment may need to be restarted once because they will not have the new state cookie.
- `api/view.svg.py` is not modified by this PR.
- PR #144 also changes `api/view.py` / the `.svg` endpoint. If #144 lands first, this branch should be rebased and the token-lifecycle changes re-audited against the resulting endpoint implementation before merge.

## Tests

Added/updated tests cover:

- OAuth state generation and hardened cookie attributes.
- Missing/mismatched state rejection.
- State cookie removal after successful callback.
- User-denied (`access_denied`) authorization without token exchange.
- Valid-state callbacks missing both `code` and `error`.
- Absolute expiry persistence on initial authorization.
- No bearer token output to stdout/stderr.
- Refresh response without token rotation.
- Refresh response with token rotation.
- Transient refresh errors preserving stored credentials.
- Incomplete refresh responses preserving stored credentials.
- Transient refresh failures returning a retryable server error instead of a re-login message.
- Invalid `expires_in` metadata.

## Review / CI status

The complete diff has been re-audited after the follow-up fixes. The PR is currently mergeable and contains changes to six files only.

The upstream `Python Flask CI/CD` workflow is still reported as `action_required`: GitHub created the workflow run but did not start jobs because this fork contribution requires maintainer approval. The current head therefore still needs the upstream pytest/CI run before merge.